### PR TITLE
Fix .key file with a wrong name being referenced.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Dearmor the public key into the new binary format
   shell:
-    cmd: "cat /usr/local/src/netbird-wiretrustee-public.key | gpg --dearmor -o /usr/share/keyrings/netbird-archive-keyring.gpg"
+    cmd: "cat /usr/share/keyrings/netbird-archive-keyring.key | gpg --dearmor -o /usr/share/keyrings/netbird-archive-keyring.gpg"
     creates: /usr/share/keyrings/netbird-archive-keyring.gpg
 
 - name: Install apt repository
@@ -54,5 +54,5 @@
     state: absent
   loop:
     - /etc/apt/sources.list.d/netbird-wiretrustee.list
-    - /usr/local/src/netbird-wiretrustee-public.key
+    - /usr/share/keyrings/netbird-archive-keyring.key
     - /etc/apt/trusted.gpg.d/wiretrustee.gpg


### PR DESCRIPTION
The get_url command downloads /usr/share/keyrings/netbird-archive-keyring.key but the cat command referenced a non-existing file resuling in a zero byte .gpg file.